### PR TITLE
Refactoring path relations & config settings

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# folders
+.idea
+.github
+__pycache__
+dockerimage
+logs
+venv
+# files
+.gitignore
+Dockerfile
+compose.yaml
+README.md

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,4 @@
 /exports/
 /logs/
 /core/tests/logs/
-/core/scratch.py
-scratch.py
+*scratch.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,8 @@ RUN apt install -y nano
 
 # Project Paths
 ENV dWDIR=/ispcontool/
-ENV dCORE=${dWDIR}core/
-ENV sCORE=/core
 
 # Project Vars
-ENV BASE_DIR=$dWDIR
 ENV TIME_INTERVAL=8
 ENV TIME_MODE=D
 ENV TIME_TOLERANCE=5
@@ -28,22 +25,13 @@ ENV SUB_ROUTINE_SLEEP=60
 ENV SUB_RATE=1
 
 # Project prep
-COPY main.py $dWDIR
-COPY $sCORE/config.py $dCORE
-COPY $sCORE/cfg_default.py $dCORE
-COPY $sCORE/cfg_docker.py $dCORE
-COPY $sCORE/datautils.py $dCORE
-COPY $sCORE/exceptions.py $dCORE
-COPY $sCORE/fileutils.py $dCORE
-COPY $sCORE/logger.py $dCORE
-COPY $sCORE/mocks.py $dCORE
-COPY $sCORE/portutils.py $dCORE
-COPY $sCORE/signalutils.py $dCORE
-COPY $sCORE/timeutils.py $dCORE
+COPY . $dWDIR
 
 # Project permissions
 RUN chmod -R u+rwx $dWDIR
 
 WORKDIR $dWDIR
+
+RUN python3 './setup.py'
 
 CMD ["python3", "-u", "/ispcontool/main.py"]

--- a/README.md
+++ b/README.md
@@ -46,11 +46,8 @@ false-negative responses.
 ---
 ## Usage
 ### Docker
-If you want to build a Docker image, you have to perform some steps in advance, before you can build it with the
-contained **Dockerfile**.  
-
-1. **/core/config.py** -> Change the variable **docker_conf** to **True**
-2. **./Dockerfile** -> (Optional) Define the environment variables to your needs
+If you want to build a Docker image, there's a **Dockerfile** in the root folder.
+Just adjust the environment variables inside the file.
 
 ### Environment Variables
 
@@ -110,11 +107,14 @@ If you define **SUB_RATE=1.5** and **MAIN_ROUTINE_SLEEP=30**, the main routine d
 
 ---
 ### Without Docker
-For using it without Docker, check the config file first:
-- **/core/config.py** -> The variable **docker_conf** should be **False**
+For using it without Docker you have to execute the **setup.py** once, so the base path gets updated:
+```commandline
+python setup.py
+```
 
-After that change the time values to your needs. More information about the time values, 
-read the section "Environment Variables".
+After that head to **core/config.py** and modify the variable **HOSTS** to your needs. Second, head to
+**core/configs/default.py** and change the time values to your needs.  
+For more information about the time values, read the section "Environment Variables".
 
 Now just start the **./main.py** file.
 ```commandline

--- a/core/config.py
+++ b/core/config.py
@@ -1,14 +1,23 @@
 #!/usr/bin/env python 
 # -*- coding:utf-8 -*-
-import core.cfg_default
-import core.cfg_docker
-
-docker_conf: bool = True
+import core.configs.default
+import core.configs.docker
+import core.conutils
 
 
 class Interface:
     def __init__(self):
-        if not docker_conf:
-            self.config = core.cfg_default.Conf()
+        self.is_container: bool = core.conutils.is_container()
+
+        # Hosts to check
+        self.HOSTS: list[str, ...] = [
+            'google.com',
+            'x.com',
+            'duckduckgo.com'
+        ]
+
+    def config(self):
+        if not self.is_container:
+            return core.configs.default.Conf()
         else:
-            self.config = core.cfg_docker.Conf()
+            return core.configs.docker.Conf()

--- a/core/configs/default.py
+++ b/core/configs/default.py
@@ -1,20 +1,13 @@
 #!/usr/bin/env python 
 # -*- coding:utf-8 -*-
 import core.logger
+import os
 
 log = core.logger.Logger(__file__)
 
 
 class Conf:
     def __init__(self):
-        log.this(0, 'Using Manual Config')
-        #
-        # PATHS
-        #
-        self.BASE_DIR: str = 'M:/PYTHON/ispcontool'
-        # self.BASE_DIR: str = 'ispcontool'
-        self.EXPORT_DIR: str = 'exports'
-
         #
         # CSV
         #
@@ -22,7 +15,6 @@ class Conf:
         File name format will be:
            isp_connectivity-report_2023.csv
         """
-        self.CSV_FOLDER: str = 'csv'
         self.CSV_FILENAME_PREFIX: str = 'isp'
         self.CSV_FILENAME_MID: str = 'connectivity-report'
         self.CSV_FILE_EXTENSION: str = 'csv'
@@ -34,15 +26,6 @@ class Conf:
         self.TIME_INTERVAL = 30  # n times
         self.TIME_MODE = 'H'  # D -> per day / H -> per hour
         self.TIME_TOLERANCE = 1  # minutes
-
-        #
-        # Hosts to check
-        #
-        self.HOSTS: list[str, ...] = [
-            'google.com',
-            'x.com',
-            'duckduckgo.com'
-        ]
 
         #
         # Routine config

--- a/core/configs/docker.py
+++ b/core/configs/docker.py
@@ -8,13 +8,6 @@ log = core.logger.Logger(__file__)
 
 class Conf:
     def __init__(self):
-        log.this(0, 'Using Docker Config')
-        #
-        # PATHS
-        #
-        self.BASE_DIR: str = os.environ['BASE_DIR']
-        self.EXPORT_DIR: str = 'exports'
-
         #
         # CSV
         #
@@ -22,7 +15,6 @@ class Conf:
         File name format will be:
            isp_connectivity-report_2023.csv
         """
-        self.CSV_FOLDER: str = 'csv'
         self.CSV_FILENAME_PREFIX: str = 'isp'
         self.CSV_FILENAME_MID: str = 'connectivity-report'
         self.CSV_FILE_EXTENSION: str = 'csv'
@@ -34,15 +26,6 @@ class Conf:
         self.TIME_INTERVAL: int = int(os.environ['TIME_INTERVAL'])  # n times
         self.TIME_MODE: str = os.environ['TIME_MODE']  # D -> per day / H -> per hour
         self.TIME_TOLERANCE: int = int(os.environ['TIME_TOLERANCE'])  # minutes
-
-        #
-        # Hosts to check
-        #
-        self.HOSTS: list[str, ...] = [
-            'google.com',
-            'x.com',
-            'duckduckgo.com'
-        ]
 
         #
         # Routine config

--- a/core/conutils.py
+++ b/core/conutils.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python 
+# -*- coding:utf-8 -*-
+import sys
+
+
+def is_container():
+    current_platform: str = sys.platform.lower()
+
+    if current_platform in ['linux', 'darwin']:
+        with open('/proc/self/cgroup', 'r') as p:
+            for x in p:
+                fields = x.strip().split('/')
+                if fields[1] == 'docker':
+                    return True
+    elif current_platform in ['win32']:
+        # not implemented yet
+        # wth do you would even run a container in a Windows env?!
+        return False
+    else:
+        return False

--- a/core/fileutils.py
+++ b/core/fileutils.py
@@ -6,9 +6,10 @@ import sys
 from datetime import datetime as dt
 import core.config
 import core.logger
+import core.paths as paths
 
 log = core.logger.Logger(__file__)
-cfg = core.config.Interface().config
+cfg = core.config.Interface().config()
 
 
 class FileUtils:
@@ -16,10 +17,7 @@ class FileUtils:
         self.system = sys.platform.lower()
         self.dt_format_to_year: str = '%Y'
         self.dt_now_year = dt.now().strftime(self.dt_format_to_year)
-        self.csv_file_path: str = f'{self.os_path(cfg.BASE_DIR.strip("/"))}/' \
-                                  f'{cfg.EXPORT_DIR.strip("/")}/' \
-                                  f'{cfg.CSV_FOLDER.strip("/")}/'
-
+        self.csv_file_path: str = paths.CSV_FOLDER + '/'
         self.csv_file_name: str = f'{cfg.CSV_FILENAME_PREFIX}' \
                                   f'_{cfg.CSV_FILENAME_MID}' \
                                   f'_{self.dt_now_year}' \
@@ -70,6 +68,5 @@ class FileUtils:
         pathlib.Path(path).mkdir(parents=True, exist_ok=True)
 
     def __create_folders_export_csv(self) -> None:
-        export_dir: str = f'{self.os_path(cfg.BASE_DIR)}/{cfg.EXPORT_DIR}'
-        csv_dir: str = f'{export_dir}/{cfg.CSV_FOLDER}'
-        self.__create_folder(csv_dir)
+        export_csv_dir: str = paths.CSV_FOLDER
+        self.__create_folder(export_csv_dir)

--- a/core/logger.py
+++ b/core/logger.py
@@ -3,6 +3,8 @@
 import datetime as dt
 import pathlib
 import sys
+import core.paths as paths
+
 
 current_ts: str = dt.datetime.now().strftime('%y-%m-%d_%H%M%S')
 
@@ -19,7 +21,7 @@ class Logger:
         self.ts: str = current_ts
         self.file_save: bool = True
         self.file_name: str = f'log_{self.ts}.log'
-        self.file_path: str = './logs'
+        self.file_path: str = paths.LOG_DIR
         self.file_full_path: str = f'{self.file_path}/{self.file_name}'
         self.std: bool = True
         self.max_levels = len(self.log_levels.keys())

--- a/core/paths.py
+++ b/core/paths.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+
+BASE_DIR: str = r'M:/PYTHON/ispcontool'
+EXPORT_DIR: str = BASE_DIR + '/exports'
+CSV_FOLDER: str = EXPORT_DIR + '/csv'
+LOG_DIR: str = BASE_DIR + '/logs'

--- a/core/tests/test_timeutils.py
+++ b/core/tests/test_timeutils.py
@@ -9,6 +9,7 @@ import datetime
 import core.timeutils
 import core.exceptions
 import core.logger
+import core.config
 
 log = core.logger.Logger(__file__)
 log.file_save = False

--- a/core/timeutils.py
+++ b/core/timeutils.py
@@ -5,8 +5,8 @@ import core.config
 import core.exceptions
 import core.logger
 
-cfg = core.config.Interface().config
 log = core.logger.Logger(__file__)
+cfg = core.config.Interface().config()
 
 
 class TimeUtils:

--- a/main.py
+++ b/main.py
@@ -6,11 +6,12 @@ from core import timeutils
 from core import fileutils
 from core import portutils
 from core import datautils
+import core.conutils
 import core.config
 import core.logger
 
 log = core.logger.Logger(__file__)
-cfg = core.config.Interface().config
+cfg = core.config.Interface()
 
 
 class Main:
@@ -20,6 +21,11 @@ class Main:
         self.time_utl = timeutils.TimeUtils()
         self.sig_utl = signalutils.Terminate()
         self.data_utl = datautils.DataUtils()
+        self.is_container: bool = core.conutils.is_container()
+        if not self.is_container:
+            log.this(1, 'Using Manual Config')
+        else:
+            log.this(1, 'Using Docker Config')
 
     def main_routine(self):
         log.this(1, 'Started Main Routine')
@@ -45,7 +51,7 @@ class Main:
                 if not hosts_online:
                     # 3. Fact: Hosts are offline
                     self.sub_routine()
-            self.sig_utl.sleep(cfg.MAIN_ROUTINE_SLEEP)
+            self.sig_utl.sleep(cfg.config().MAIN_ROUTINE_SLEEP)
 
     def sub_routine(self):
         log.this(1, 'Started Sub Routine')
@@ -62,7 +68,7 @@ class Main:
                 self.file_utl.write_to_csv(csv_out)
                 print('CSV\t', csv_out)
                 break
-            self.sig_utl.sleep(cfg.SUB_ROUTINE_SLEEP, cfg.SUB_RATE)
+            self.sig_utl.sleep(cfg.config().SUB_ROUTINE_SLEEP, cfg.config().SUB_RATE)
 
 
 if __name__ == '__main__':

--- a/mock_main.py
+++ b/mock_main.py
@@ -8,6 +8,7 @@ from core import fileutils
 from core import portutils
 from core import datautils
 from core import mocks
+import core.conutils
 import core.logger
 
 log = core.logger.Logger(__file__)
@@ -24,6 +25,12 @@ class MockMain:
         self.sig_utl = signalutils.Terminate()
         self.data_utl = datautils.DataUtils()
         self.mocks = mocks.Mocks()
+        self.is_container: bool = core.conutils.is_container()
+        if not self.is_container:
+            log.this(1, 'Using Manual Config')
+        else:
+            log.this(1, 'Using Docker Config')
+
         # Test Data
         self.main_routine_sleep = 1
         self.sub_routine_sleep = 1

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python 
+# -*- coding:utf-8 -*-
+import os
+import re
+import datetime
+
+
+def set_base_path() -> str:
+    # minilog
+    def log(msg):
+        dt = datetime.datetime.now()
+        out = f'{dt} INFO [setup]: {msg}'
+        print(out)
+        return out
+
+    paths_py: str = 'core/paths.py'
+    current_dir: str = os.path.abspath('')
+    current_dir = current_dir.replace('\\', '/')
+    log(f'Current Dir: {current_dir}')
+
+    log(f'Reading {paths_py} ...')
+    with open(paths_py, 'r', encoding='utf8') as f:
+        pyfile = f.read()
+    log('Reading done')
+
+    log('Replacing strings ...')
+    pattern = r"BASE_DIR: str = r'.+'"
+    replace_by = f"BASE_DIR: str = r'{current_dir}'"
+    pyfile = re.sub(pattern, replace_by, pyfile)
+    log('Strings replaced')
+
+    log(f'Writing content into {paths_py} ...')
+    with open(paths_py, 'w+', encoding='utf8') as p:
+        p.write(pyfile)
+    log('Done writing')
+
+
+if __name__ == '__main__':
+    set_base_path()


### PR DESCRIPTION
- config.py
  - moved the variable HOSTS from the individual configs to the config.py so there's less code duplication
  - moved the default- and the docker-config on level down
  - refactoring on other places, where the config.py is used
  - removed all path declarations and moved it to the new paths.py

- added conutils.py
  - determines if this project is running inside a Docker container
  - if it's inside a container, it uses the Docker config, otherwise it uses the default config

- Dockerfile
  - simplified the Dockerfile and added a .dockerignore

- setup.py
  - since the current pathing was quite inconvenient and led to some side effects, paths will now be created by the setup.py and must be run once

- updated the README.md